### PR TITLE
Pokemon DTO Type fix

### DIFF
--- a/pokemon-checker/src/DataTransferObjects/PokemonDTO.ts
+++ b/pokemon-checker/src/DataTransferObjects/PokemonDTO.ts
@@ -1,14 +1,9 @@
 type PokemonConstructorOptions = {
   name: string;
-  dexId: number;
-  types: {type:{name: string}}[];
-  moves: {
-    move: {
-      name: string;
-      url: string;
-    };
-  }[];
-  sprites: {front_shiny: string, front_default: string}
+  id: number;
+  types: { type: { name: string } }[];
+  moves: { name: string; url: string }[];
+  sprites: { front_shiny: string; front_default: string };
 };
 
 /**
@@ -21,12 +16,7 @@ class PokemonDTO {
   public dexId: number;
   public type1: string; //TODO: Update this to a TypeDTO object when created
   public type2: string | null;
-  public moves: {
-    move: {
-      name: string;
-      url: string;
-    };
-  }[]; //TODO: Update this to a moveDTO[] object when created
+  public moves:{ name: string; url: string }[]; //TODO: Update this to a moveDTO[] object when created
   public frontDefault: string;
   public frontShiny: string;
 


### PR DESCRIPTION
Just wanted to make sure we're policing the objects we use to instantiate our classes, so I've made the constructor options for a pokemon DTO a proper type.

Also included here is re-running `Prettier` to ensure the style stays consistent on this file - there were some lingering tabs and uneven whitespace.

Lastly, I took the previous definition for "moves" and simplified it: there's no need for us to have an array of objects with 1 key, containing an object with 2 keys. It's been reduced to an array of objects with 2 keys, but of course this is subject to change once the `MoveDTO` is written.