### PR TITLE
Added colour and padding styles to Element Types

### DIFF
--- a/pokemon-checker/src/DataTransferObjects/PokemonDTO.ts
+++ b/pokemon-checker/src/DataTransferObjects/PokemonDTO.ts
@@ -1,5 +1,7 @@
 import { MoveDTO } from "./MoveDTO";
 import { ITypeData, ISpriteData } from "../interfaces/PokemonData";
+import { ElementType } from "../constants/ElementTypes";
+import { getTypeFromData } from "../utils/PokemonTypeUtils";
 
 export type PokemonConstructorOptions = {
   name: string;
@@ -25,27 +27,6 @@ export type pokemonDisplayObj = {
   };
 };
 
-export enum ElementType {
-  BUG = "bug",
-  DARK = "dark",
-  DRAGON = "dragon",
-  ELECTRIC = "electric",
-  FAIRY = "fairy",
-  FIGHTING = "fighting",
-  FIRE = "fire",
-  FLYING = "flying",
-  GHOST = "ghost",
-  GRASS = "grass",
-  GROUND = "ground",
-  ICE = "ice",
-  NORMAL = "normal",
-  POISON = "poison",
-  PSYCHIC = "psychic",
-  ROCK = "rock",
-  STEEL = "steel",
-  WATER = "water",
-}
-
 /**
  * Pokemon stat data is (currently) sent in an array where
  * stat indices are consistent with this enum
@@ -67,8 +48,8 @@ enum pokemonStatIndex {
 class PokemonDTO {
   public name: string;
   public dexId: number;
-  public type1: string; //TODO: Update this to a TypeDTO object when created
-  public type2: string | null;
+  public type1: ElementType;
+  public type2: ElementType | null;
   public moves: MoveDTO[];
   public frontDefault: string;
   public frontShiny: string;
@@ -90,9 +71,9 @@ class PokemonDTO {
     this.name = pokemonConstructorOptions.name;
     this.dexId = pokemonConstructorOptions.id;
     this.moves = pokemonConstructorOptions.moves;
-    this.type1 = pokemonConstructorOptions.types[0].name ?? "";
+    this.type1 = getTypeFromData(pokemonConstructorOptions.types[0].name);
     this.type2 = pokemonConstructorOptions.types[1]
-      ? pokemonConstructorOptions.types[1].name
+      ? getTypeFromData(pokemonConstructorOptions.types[1].name)
       : null;
     this.frontDefault = pokemonConstructorOptions.sprites.front_default;
     this.frontShiny = pokemonConstructorOptions.sprites.front_shiny;

--- a/pokemon-checker/src/DataTransferObjects/PokemonDTO.ts
+++ b/pokemon-checker/src/DataTransferObjects/PokemonDTO.ts
@@ -49,7 +49,7 @@ class PokemonDTO {
   public name: string;
   public dexId: number;
   public type1: ElementType;
-  public type2: ElementType | null;
+  public type2: ElementType;
   public moves: MoveDTO[];
   public frontDefault: string;
   public frontShiny: string;
@@ -74,7 +74,7 @@ class PokemonDTO {
     this.type1 = getTypeFromData(pokemonConstructorOptions.types[0].name);
     this.type2 = pokemonConstructorOptions.types[1]
       ? getTypeFromData(pokemonConstructorOptions.types[1].name)
-      : null;
+      : ElementType.NULL;
     this.frontDefault = pokemonConstructorOptions.sprites.front_default;
     this.frontShiny = pokemonConstructorOptions.sprites.front_shiny;
     this.url = pokemonConstructorOptions.url ?? "";

--- a/pokemon-checker/src/_stubs/PokemonData.ts
+++ b/pokemon-checker/src/_stubs/PokemonData.ts
@@ -1,8 +1,9 @@
 import {
-  ElementType,
+  
   PokemonConstructorOptions,
 } from "../DataTransferObjects/PokemonDTO";
 import { MoveDTO } from "../DataTransferObjects/MoveDTO";
+import { ElementType } from "../constants/ElementTypes";
 
 /**
  * Input object for creating a pokemon DTO

--- a/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/NameDisplay.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/NameDisplay.tsx
@@ -1,6 +1,6 @@
 type pokemonNameAndId = {
-  name: string,
-  id: string
+  name: string;
+  id: number;
 };
 
 export const NameDisplay = ({ name, id }: pokemonNameAndId) => {

--- a/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/StatDisplay.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/StatDisplay.tsx
@@ -1,16 +1,22 @@
 import { styled } from "@mui/material/styles";
-import { Table, TableBody, TableCell, TableRow, tableCellClasses } from "@mui/material";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  tableCellClasses,
+} from "@mui/material";
 
 const StyledTableCell = styled(TableCell)(({ theme }) => ({
   [`&.${tableCellClasses.body}`]: {
     color: theme.palette.common.white,
     fontSize: 14,
-    textAlign: "center"
+    textAlign: "center",
   },
 }));
 
 type pokemonStats = {
-  baseStats: string
+  baseStats: number;
   stats: {
     hp: number;
     attack: number;
@@ -18,15 +24,13 @@ type pokemonStats = {
     spAttack: number;
     spDefense: number;
     speed: number;
-  } | null
+  } | null;
 };
 
 export const StatDisplay = ({ baseStats, stats }: pokemonStats) => {
   return (
     <div id="PokemonBaseStats">
-      <h5>
-        {baseStats}
-      </h5>
+      <h5>{baseStats}</h5>
       <Table sx={{ minWidth: 300 }} aria-label="stat table" color="white">
         <TableBody>
           <TableRow>

--- a/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/TypeDisplay.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/TypeDisplay.tsx
@@ -1,16 +1,13 @@
 type pokemonTypes = {
-  type1: string,
-  type2: string | null
+  type: string | null;
 };
 
-export const TypeDisplay  = ({type1, type2}: pokemonTypes) => {
-  return (
-    <div id="PokemonTypes">
-      <h5>
-        {type1} {type2}
-      </h5>
-    </div>
-  );
+export const TypeDisplay = ({ type }: pokemonTypes) => {
+  if (!type) {
+    return <></>;
+  }
+
+  return <span>{type}</span>;
 };
 
 export default TypeDisplay;

--- a/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/TypeDisplay.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/TypeDisplay.tsx
@@ -1,9 +1,11 @@
-type pokemonTypes = {
-  type: string | null;
-};
+import { ElementType } from "../../../constants/ElementTypes";
 
-export const TypeDisplay = ({ type }: pokemonTypes) => {
-  if (!type) {
+type TypeDisplayProps = {
+  type: ElementType
+}
+
+export const TypeDisplay = ({ type }: TypeDisplayProps) => {
+  if (type === ElementType.NULL) {
     return <></>;
   }
 

--- a/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/TypeDisplay.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/TypeDisplay.tsx
@@ -1,15 +1,95 @@
 import { ElementType } from "../../../constants/ElementTypes";
 
 type TypeDisplayProps = {
-  type: ElementType
-}
+  type: ElementType;
+};
+
+const spaceStyles = {
+  borderRadius: "0.25rem",
+  margin: "0 0.2rem",
+  padding: "0 0.3rem",
+  width: "100%"
+};
+
+const getColourStyles = (type: ElementType) => {
+  const colourObject = {
+    backgroundColor: "",
+    color: "#fff",
+    textShadow: "1px 1px 2px #000",
+  };
+  switch (type) {
+    case ElementType.BUG:
+      colourObject.backgroundColor = "#71c049";
+      break;
+    case ElementType.DARK:
+      colourObject.backgroundColor = "#564336";
+      break;
+    case ElementType.DRAGON:
+      colourObject.backgroundColor = "#510ff0";
+      break;
+    case ElementType.ELECTRIC:
+      colourObject.backgroundColor = "#f1c310";
+      break;
+    case ElementType.FAIRY:
+      colourObject.backgroundColor = "#f65bff";
+      break;
+    case ElementType.FIGHTING:
+      colourObject.backgroundColor = "#b32c25";
+      break;
+    case ElementType.FIRE:
+      colourObject.backgroundColor = "#eb7928";
+      break;
+    case ElementType.FLYING:
+      colourObject.backgroundColor = "#9c87d9";
+      break;
+    case ElementType.GHOST:
+      colourObject.backgroundColor = "#66508b";
+      break;
+    case ElementType.GRASS:
+      colourObject.backgroundColor = "#6ebd47";
+      break;
+    case ElementType.GROUND:
+      colourObject.backgroundColor = "#ddbb5d";
+      break;
+    case ElementType.ICE:
+      colourObject.backgroundColor = "#8fd4d4";
+      break;
+    case ElementType.NORMAL:
+      colourObject.backgroundColor = "#a0a070";
+      break;
+    case ElementType.POISON:
+      colourObject.backgroundColor = "#983c98";
+      break;
+    case ElementType.PSYCHIC:
+      colourObject.backgroundColor = "#f74f82";
+      break;
+    case ElementType.ROCK:
+      colourObject.backgroundColor = "#b09935";
+      break;
+    case ElementType.STEEL:
+      colourObject.backgroundColor = "#b2b2cb";
+      break;
+    case ElementType.WATER:
+      colourObject.backgroundColor = "#5985ee";
+      break;
+    case ElementType.NULL:
+    default:
+      colourObject.color = "inherit";
+      colourObject.backgroundColor = "inherit";
+      break;
+  }
+
+  return colourObject;
+};
 
 export const TypeDisplay = ({ type }: TypeDisplayProps) => {
   if (type === ElementType.NULL) {
     return <></>;
   }
 
-  return <span>{type}</span>;
+  const combinedStyles = { ...spaceStyles, ...getColourStyles(type) };
+
+  return <span style={combinedStyles}>{type}</span>;
 };
 
 export default TypeDisplay;

--- a/pokemon-checker/src/components/PokemonDisplay/PokemonDisplay.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/PokemonDisplay.tsx
@@ -51,7 +51,8 @@ class PokemonDisplay extends React.Component<displayProps, displayState> {
   fetchPokemonObject() {
     const url = this.props.pokemonUrl;
     if (url && url !== "") {
-      this.props.getPokemonData(url)
+      this.props
+        .getPokemonData(url)
         .then((pokemonRetrieved) => this.createPokemonObject(pokemonRetrieved))
         .catch(console.log);
     }
@@ -67,58 +68,15 @@ class PokemonDisplay extends React.Component<displayProps, displayState> {
   }
 
   render() {
-    let pokemon = this.pokemonToDisplay;
-    let pokemonName: string | undefined;
-    let dexId: string;
-    let displayDefault: string | undefined = "";
-    let displayShiny: string | undefined = "";
-    let type1: string | null;
-    let type2: string | null;
-    let stats: {
-      hp: number;
-      attack: number;
-      defense: number;
-      spAttack: number;
-      spDefense: number;
-      speed: number;
-    } | null;
-    let baseStats: string;
+    const pokemon = this.pokemonToDisplay;
 
     if (pokemon) {
-      pokemonName = pokemon.name;
-      dexId = `#${pokemon.dexId}`;
-      displayDefault = pokemon.frontDefault;
-      displayShiny = pokemon.frontShiny;
-      type1 = pokemon.type1;
-      type2 = pokemon.type2 ? pokemon.type2 : null;
-      stats = pokemon.stats;
-      baseStats = "Total base stats: " + pokemon.baseStats.toString();
-
       return (
         <Container maxWidth="sm">
-          <QuickView
-            pokemonName = {pokemonName} 
-            dexId = {dexId} 
-            baseStats = {baseStats}
-            stats = {stats}
-            type1 = {type1} 
-            type2 = {type2} 
-            displayDefault = {displayDefault} 
-            displayDefaultS = {displayShiny}
-          />
+          <QuickView pokemon={pokemon} />
         </Container>
       );
     } else {
-      // as Display gets bigger, this will get messier
-      pokemonName = "Awaiting Pokemon Selection";
-      dexId = "";
-      displayDefault = "";
-      displayShiny = "";
-      type1 = "";
-      type2 = "";
-      stats = null;
-      baseStats = "";
-
       return (
         <div className="AwaitingPokemon">
           <WaitingView />

--- a/pokemon-checker/src/components/PokemonDisplay/PokemonQuickCardView.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/PokemonQuickCardView.tsx
@@ -5,9 +5,9 @@ import PokemonImage from "./DisplayFunctionalComponents/PokemonImageDisplay";
 import Grid from "@mui/material/Grid";
 
 type PokemonInfoProps = {
-  pokemonName: string,
-  dexId: string,
-  baseStats: string,
+  pokemonName: string;
+  dexId: string;
+  baseStats: string;
   stats: {
     hp: number;
     attack: number;
@@ -15,50 +15,39 @@ type PokemonInfoProps = {
     spAttack: number;
     spDefense: number;
     speed: number;
-  } | null,
-  type1: string,
-  type2: string | null,
-  displayDefault: string,
-  displayDefaultS: string
+  } | null;
+  type1: string;
+  type2: string | null;
+  displayDefault: string;
+  displayDefaultS: string;
 };
 
-export const QuickView =  (
-  {
-    pokemonName, 
-    dexId, 
-    baseStats,
-    stats,
-    type1, 
-    type2, 
-    displayDefault, 
-    displayDefaultS
-  }: PokemonInfoProps
-) => {
-
+export const QuickView = ({
+  pokemonName,
+  dexId,
+  baseStats,
+  stats,
+  type1,
+  type2,
+  displayDefault,
+  displayDefaultS,
+}: PokemonInfoProps) => {
   return (
     <Grid container alignItems="center" columnSpacing={0}>
       <Grid item xs={12} sm={7}>
         <PokemonImage
-          altImageName = {pokemonName}
-          defaultFront = {displayDefault}
-          defaultFrontS = {displayDefaultS}
+          altImageName={pokemonName}
+          defaultFront={displayDefault}
+          defaultFrontS={displayDefaultS}
         />
       </Grid>
       <Grid item xs={12} sm>
-        <TypeDisplay
-          type1 = {type1}
-          type2 = {type2}
-        />
-        <NameDisplay
-            name = {pokemonName}
-            id = {dexId}
-          />
+        <TypeDisplay type={type1} />
+        <TypeDisplay type={type2} />
+        <NameDisplay name={pokemonName} id={dexId} />
       </Grid>
       <Grid item xs={12}>
-        <StatDisplay
-          baseStats = {baseStats}
-          stats = {stats}
-        />
+        <StatDisplay baseStats={baseStats} stats={stats} />
       </Grid>
     </Grid>
   );

--- a/pokemon-checker/src/components/PokemonDisplay/PokemonQuickCardView.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/PokemonQuickCardView.tsx
@@ -2,52 +2,30 @@ import NameDisplay from "./DisplayFunctionalComponents/NameDisplay";
 import StatDisplay from "./DisplayFunctionalComponents/StatDisplay";
 import TypeDisplay from "./DisplayFunctionalComponents/TypeDisplay";
 import PokemonImage from "./DisplayFunctionalComponents/PokemonImageDisplay";
+import PokemonDTO from "../../DataTransferObjects/PokemonDTO";
 import Grid from "@mui/material/Grid";
 
 type PokemonInfoProps = {
-  pokemonName: string;
-  dexId: string;
-  baseStats: string;
-  stats: {
-    hp: number;
-    attack: number;
-    defense: number;
-    spAttack: number;
-    spDefense: number;
-    speed: number;
-  } | null;
-  type1: string;
-  type2: string | null;
-  displayDefault: string;
-  displayDefaultS: string;
+  pokemon: PokemonDTO;
 };
 
-export const QuickView = ({
-  pokemonName,
-  dexId,
-  baseStats,
-  stats,
-  type1,
-  type2,
-  displayDefault,
-  displayDefaultS,
-}: PokemonInfoProps) => {
+export const QuickView = ({ pokemon }: PokemonInfoProps) => {
   return (
     <Grid container alignItems="center" columnSpacing={0}>
       <Grid item xs={12} sm={7}>
         <PokemonImage
-          altImageName={pokemonName}
-          defaultFront={displayDefault}
-          defaultFrontS={displayDefaultS}
+          altImageName={pokemon.name}
+          defaultFront={pokemon.frontDefault}
+          defaultFrontS={pokemon.frontShiny}
         />
       </Grid>
       <Grid item xs={12} sm>
-        <TypeDisplay type={type1} />
-        <TypeDisplay type={type2} />
-        <NameDisplay name={pokemonName} id={dexId} />
+        <TypeDisplay type={pokemon.type1} />
+        <TypeDisplay type={pokemon.type2} />
+        <NameDisplay name={pokemon.name} id={pokemon.dexId} />
       </Grid>
       <Grid item xs={12}>
-        <StatDisplay baseStats={baseStats} stats={stats} />
+        <StatDisplay baseStats={pokemon.baseStats} stats={pokemon.stats} />
       </Grid>
     </Grid>
   );

--- a/pokemon-checker/src/constants/ElementTypes.ts
+++ b/pokemon-checker/src/constants/ElementTypes.ts
@@ -1,0 +1,21 @@
+export enum ElementType {
+  BUG = "bug",
+  DARK = "dark",
+  DRAGON = "dragon",
+  ELECTRIC = "electric",
+  FAIRY = "fairy",
+  FIGHTING = "fighting",
+  FIRE = "fire",
+  FLYING = "flying",
+  GHOST = "ghost",
+  GRASS = "grass",
+  GROUND = "ground",
+  ICE = "ice",
+  NORMAL = "normal",
+  POISON = "poison",
+  PSYCHIC = "psychic",
+  ROCK = "rock",
+  STEEL = "steel",
+  WATER = "water",
+  NULL = "", // Debug empty type
+}

--- a/pokemon-checker/src/factories/PokemonFactory.ts
+++ b/pokemon-checker/src/factories/PokemonFactory.ts
@@ -1,6 +1,5 @@
 import { MoveFactory } from "./MoveFactory";
 import PokemonDTO, {
-  ElementType,
   PokemonConstructorOptions,
 } from "../DataTransferObjects/PokemonDTO";
 import {
@@ -8,6 +7,7 @@ import {
   IPokemonStub,
   ITypeData,
 } from "../interfaces/PokemonData";
+import { ElementType } from "../constants/ElementTypes";
 
 export class PokemonFactory {
   private moveFactory: MoveFactory;

--- a/pokemon-checker/src/interfaces/PokemonData.ts
+++ b/pokemon-checker/src/interfaces/PokemonData.ts
@@ -1,5 +1,5 @@
 import { damageClass } from "../DataTransferObjects/MoveDTO";
-import { ElementType } from "../DataTransferObjects/PokemonDTO";
+import { ElementType } from "../constants/ElementTypes";
 
 /**
  * ===================================================================

--- a/pokemon-checker/src/utils/PokemonTypeUtils.ts
+++ b/pokemon-checker/src/utils/PokemonTypeUtils.ts
@@ -1,0 +1,48 @@
+import { ElementType } from "../constants/ElementTypes";
+
+/**
+ * Returns a pokemon ElementType based on an input string (lowercase).
+ * @param inputType Raw string from API payload
+*/
+export const getTypeFromData = (inputType: string): ElementType => {
+  switch (inputType) {
+    case "bug":
+      return ElementType.BUG;
+    case "dark":
+      return ElementType.DARK;
+    case "dragon":
+      return ElementType.DRAGON;
+    case "electric":
+      return ElementType.ELECTRIC;
+    case "fairy":
+      return ElementType.FAIRY;
+    case "fighting":
+      return ElementType.FIGHTING;
+    case "fire":
+      return ElementType.FIRE;
+    case "flying":
+      return ElementType.FLYING;
+    case "ghost":
+      return ElementType.GHOST;
+    case "grass":
+      return ElementType.GRASS;
+    case "ground":
+      return ElementType.GROUND;
+    case "ice":
+      return ElementType.ICE;
+    case "normal":
+      return ElementType.NORMAL;
+    case "poison":
+      return ElementType.POISON;
+    case "psychic":
+      return ElementType.PSYCHIC;
+    case "rock":
+      return ElementType.ROCK;
+    case "steel":
+      return ElementType.STEEL;
+    case "water":
+      return ElementType.WATER;
+    default:
+      return ElementType.NULL;
+  }
+}


### PR DESCRIPTION
Addresses #42 .

Pokemon types now render with white text and a background colour depending on what `ElementType` was given to it.

In order to allow the `TypeDisplay` to accept `ElementType` instead of just a `string`, many things needed to be uprooted. Those details will be pointed out in the files.