### PR TITLE
Updated scripts to use legacy providers

### DIFF
--- a/pokemon-checker/package.json
+++ b/pokemon-checker/package.json
@@ -28,8 +28,8 @@
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "react-scripts --openssl-legacy-provider start",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Because I updated Node (for another project) I was no longer able to build (detailed here https://stackoverflow.com/questions/69665222/node-js-17-0-1-gatsby-error-digital-envelope-routinesunsupported-err-os)

I'm not sure if this breaks other builds, if it does we will need to reach a solution