### PR TITLE
Added recommended extension file

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "eamodio.gitlens",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,6 @@
   "recommendations": [
     "eamodio.gitlens",
     "esbenp.prettier-vscode",
-    "dbaeumer.vscode-eslint",
+    "dbaeumer.vscode-eslint"
   ]
 }


### PR DESCRIPTION
Something that was on my mind recently, I know VSCode supports [recommended extensions](https://code.visualstudio.com/updates/v1_6#_workspace-extension-recommendations) per project workspace.

I've made use of prettier, ESlint, and gitlens on my end and I think it'd probably be useful for anyone pulling this repo to have them as well. Links are below:

* [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)
* [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
* [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)

The file under `./vscode/extensions.json` has a list of their IDs and should prompt your client to install them if they're not already present. 