### PR TITLE
Memoized function and factory declarations

### DIFF
--- a/pokemon-checker/src/components/PokemonDisplay/PokemonDisplay.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/PokemonDisplay.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import PokemonDTO from "../../DataTransferObjects/PokemonDTO";
 import { IPokemonData } from "../../interfaces/PokemonData";
 import { PokemonFactory } from "../../factories/PokemonFactory";
@@ -21,14 +21,27 @@ type displayProps = {
 
 export const PokemonDisplay = (props: displayProps) => {
   const [pokeonObject, setPokemonObject] = useState<PokemonDTO>();
-  //TODO (jeremy): Move this factory to a service! Views shouldn't control this.
-  const pokemonFactory: PokemonFactory = new PokemonFactory();
+  // TODO (jeremy): Elminate the factory declaration! The service method is
+  // passed to this component as a prop.
+  const pokemonFactory: PokemonFactory = useMemo(
+    () => new PokemonFactory(),
+    []
+  );
+  /**
+   * Create a PokemonObject from the results retrieved
+   * @param pokemonRetrieved the pokemon retrieved from the API
+   */
+  const createPokemonObject = useCallback(
+    (pokemonRetrieved: IPokemonData): void => {
+      let pokemonToDisplay = pokemonFactory.createPokemon(pokemonRetrieved);
+      setPokemonObject(pokemonToDisplay);
+    },
+    [pokemonFactory]
+  );
 
-  useEffect(() => {
-    fetchPokemonObject();
-  });
-
-  const fetchPokemonObject = () => {
+  // TODO: Eliminate this method. 'getPokemonData' as a Service method
+  // should already return the PokemonDTO - it currently returns raw JSON.
+  const fetchPokemonObject = useCallback(() => {
     const url = props.pokemonUrl;
     if (url && url.length > 0) {
       props
@@ -36,16 +49,11 @@ export const PokemonDisplay = (props: displayProps) => {
         .then((pokemonRetrieved) => createPokemonObject(pokemonRetrieved))
         .catch(console.log);
     }
-  };
+  }, [props, createPokemonObject]);
 
-  /**
-   * Create a PokemonObject from the results retrieved
-   * @param pokemonRetrieved the pokemon retrieved from the API
-   */
-  const createPokemonObject = (pokemonRetrieved: IPokemonData): void => {
-    let pokemonToDisplay = pokemonFactory.createPokemon(pokemonRetrieved);
-    setPokemonObject(pokemonToDisplay);
-  };
+  useEffect(() => {
+    fetchPokemonObject();
+  }, [fetchPokemonObject]);
 
   if (pokeonObject) {
     return (

--- a/pokemon-checker/src/components/PokemonDisplay/PokemonDisplay.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/PokemonDisplay.tsx
@@ -20,7 +20,7 @@ type displayProps = {
 };
 
 export const PokemonDisplay = (props: displayProps) => {
-  const [pokeonObject, setPokemonObject] = useState<PokemonDTO>();
+  const [pokemonObject, setPokemonObject] = useState<PokemonDTO>();
   // TODO (jeremy): Elminate the factory declaration! The service method is
   // passed to this component as a prop.
   const pokemonFactory: PokemonFactory = useMemo(
@@ -55,10 +55,10 @@ export const PokemonDisplay = (props: displayProps) => {
     fetchPokemonObject();
   }, [fetchPokemonObject]);
 
-  if (pokeonObject) {
+  if (pokemonObject) {
     return (
       <DisplayBorder maxWidth="sm">
-        <QuickView pokemon={pokeonObject} />
+        <QuickView pokemon={pokemonObject} />
       </DisplayBorder>
     );
   } else {


### PR DESCRIPTION
I noticed after running the app that we were doing duplicate calls for all Pokemon + images we were rendering. The calls were coming from the service, but ultimately, it was the `PokemonDisplay.tsx` file that was trying to re-fetch the data all the time.

At its core, I believe it was because of how we implemented `useEffect` in #70 . When the hook was first put in, there were no dependencies fed to it. This will cause it to default to the behaviour of running `useEffect` every time the component renders.

I've fed the appropriate dependencies to `useEffect`, and wrapped some declarations in `useCallback` and `useMemo` for performance reasons. Details will be annotated in the file.