### PR TITLE
Refactor Ability Repository for proper expiry

### DIFF
--- a/pokemon-checker/src/services/AbilityService.ts
+++ b/pokemon-checker/src/services/AbilityService.ts
@@ -30,8 +30,6 @@ export class AbilityService {
       this.repository.setAbilityData(payload);
       this.repository.saveAbility();
 
-      // Set the timestamp for 30 minutes
-      this.repository.setExpiryTimestamp(30);
     } catch (e: unknown) {
       if (typeof e === "string") {
         console.log(`Could not store ability stubs: ${e}`);
@@ -84,7 +82,7 @@ export class AbilityService {
    * @returns either the retrieved ability or nothing
    */
   private repositoryLookup(key: string): AbilityDTO | undefined {
-    if (!this.repository.isExpired) {
+    if (!this.repository.isExpired(key)) {
       const findAbility = this.repository.getAbility(key);
       if (findAbility) return findAbility;
     }


### PR DESCRIPTION
When we set a local storage for expiry, it creates a new record, while this is nice for big blobs (all pokemon), we'd need to create one for each individual object (specific pokemon, ability, move etc). I feel its better to store this in the record itself rather than create a new UNIQUE entry because otherwise we'd need an expiry record in the table for EACH object. While this is an approach, I think storing it in the object makes more sense when checking since we can just look at that table record's expiry, and not look at a second record that loosely points to it.

What I did was rewrote the repository to STORE the expiry with the object, and will update whenever an update is made to it (use case? not sure yet, maybe if the app/api makes an update that we need to run in the background we can update the repository). A further update to PokemonRepository would need to be made because individual pokemon lookup is not using it right now, only the blob at the start of the application run is.

What I need to verify
1. When it expires, would refetching/setting in the repository overwrite the existing value? Do we need to clear it before hand?
2. What are the proper use cases of resetting the expiry (if a user looks at a pokemon with an ability that exists in the repo, do we want to update that expiry? leave it alone?