### PR TITLE
Big push for ability localization (sorry)

### DIFF
--- a/pokemon-checker/package-lock.json
+++ b/pokemon-checker/package-lock.json
@@ -21,8 +21,7 @@
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "react-scripts": "^5.0.0",
-        "react-test-renderer": "^17.0.2",
-        "tachyons": "^4.12.0"
+        "react-test-renderer": "^17.0.2"
       },
       "devDependencies": {
         "@types/jest": "^27.0.3",
@@ -14851,11 +14850,6 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
-    "node_modules/tachyons": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/tachyons/-/tachyons-4.12.0.tgz",
-      "integrity": "sha512-2nA2IrYFy3raCM9fxJ2KODRGHVSZNTW3BR0YnlGsLUf1DA3pk3YfWZ/DdfbnZK6zLZS+jUenlUGJsKcA5fUiZg=="
-    },
     "node_modules/tailwindcss": {
       "version": "3.0.23",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.23.tgz",
@@ -26974,11 +26968,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
-    },
-    "tachyons": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/tachyons/-/tachyons-4.12.0.tgz",
-      "integrity": "sha512-2nA2IrYFy3raCM9fxJ2KODRGHVSZNTW3BR0YnlGsLUf1DA3pk3YfWZ/DdfbnZK6zLZS+jUenlUGJsKcA5fUiZg=="
     },
     "tailwindcss": {
       "version": "3.0.23",

--- a/pokemon-checker/package.json
+++ b/pokemon-checker/package.json
@@ -17,8 +17,7 @@
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-scripts": "^5.0.0",
-    "react-test-renderer": "^17.0.2",
-    "tachyons": "^4.12.0"
+    "react-test-renderer": "^17.0.2"
   },
   "jest": {
     "transform": {

--- a/pokemon-checker/src/App.css
+++ b/pokemon-checker/src/App.css
@@ -1,16 +1,10 @@
+html, body, .App {
+  /* Fills up the entire app, without it there's a white bar at top and right side*/
+  overflow: auto; 
+}
+
 .App {
   text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
 }
 
 .App {
@@ -18,21 +12,4 @@
   min-height: 100vh;
   font-size: calc(10px + 2vmin);
   color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-.pokedex {
-  margin: auto;
-  width: 60%;
-}
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
 }

--- a/pokemon-checker/src/App.css
+++ b/pokemon-checker/src/App.css
@@ -1,6 +1,8 @@
-html, body, .App {
+html,
+body,
+.App {
   /* Fills up the entire app, without it there's a white bar at top and right side*/
-  overflow: auto; 
+  overflow: auto;
 }
 
 .App {

--- a/pokemon-checker/src/App.tsx
+++ b/pokemon-checker/src/App.tsx
@@ -45,15 +45,16 @@ class App extends Component<any, AppState> {
     let filteredPokemon: PokemonDTO[] = [];
     if (event && event.target && event.target.value) {
       const searchField = event.target.value;
-      filteredPokemon = searchField.length > 1 ? 
-        this.state.pokemonList.filter((pokemon) => {
-          let name: string = pokemon.name.toLowerCase();
-          return name.includes(searchField.toLowerCase());
-        }) :
-        [];
+      filteredPokemon =
+        searchField.length > 1
+          ? this.state.pokemonList.filter((pokemon) => {
+              let name: string = pokemon.name.toLowerCase();
+              return name.includes(searchField.toLowerCase());
+            })
+          : [];
     }
-      this.setState({ pokemonResults: filteredPokemon });
-    };
+    this.setState({ pokemonResults: filteredPokemon });
+  };
 
   onPokemonSelected = (url: string) => {
     if (url && url !== "") {
@@ -63,7 +64,7 @@ class App extends Component<any, AppState> {
 
   render() {
     const { pokemonResults, pokemonUrl } = this.state;
-  
+
     return (
       <div className="App">
         <h1>Search for a Pokemon</h1>

--- a/pokemon-checker/src/App.tsx
+++ b/pokemon-checker/src/App.tsx
@@ -10,9 +10,7 @@ import { scrubPokemonName } from "./utils/NameScrubbingHelper";
 
 type AppState = {
   pokemonList: PokemonDTO[];
-  pokemonName: string;
-  searchfield: string;
-  pokemonSelected: string;
+  pokemonResults: PokemonDTO[];
   pokemonUrl: string;
 };
 
@@ -23,9 +21,7 @@ class App extends Component<any, AppState> {
     super(props);
     this.state = {
       pokemonList: [],
-      pokemonName: "",
-      searchfield: "",
-      pokemonSelected: "",
+      pokemonResults: [],
       pokemonUrl: "",
     };
 
@@ -46,35 +42,35 @@ class App extends Component<any, AppState> {
   }
 
   onSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    let filteredPokemon: PokemonDTO[] = [];
     if (event && event.target && event.target.value) {
-      this.setState({ searchfield: event.target.value });
+      const searchField = event.target.value;
+      filteredPokemon = searchField.length > 1 ? 
+        this.state.pokemonList.filter((pokemon) => {
+          let name: string = pokemon.name.toLowerCase();
+          return name.includes(searchField.toLowerCase());
+        }) :
+        [];
     }
-  };
+      this.setState({ pokemonResults: filteredPokemon });
+    };
 
-  onPokemonSelected = (pokemonClicked: string, url: string) => {
+  onPokemonSelected = (url: string) => {
     if (url && url !== "") {
-      this.setState({ pokemonSelected: pokemonClicked, pokemonUrl: url });
+      this.setState({ pokemonUrl: url });
     }
   };
 
   render() {
-    const { pokemonList, searchfield, pokemonUrl } = this.state;
-    let filteredPokemon: any[] = [];
-    if (searchfield.length < 2) {
-      //do nothing, only really want to start searching when we have at least 2 characters
-    } else {
-      filteredPokemon = pokemonList.filter((pokemon) => {
-        let name: string = pokemon.name.toLowerCase();
-        return name.includes(searchfield.toLowerCase());
-      });
-    }
+    const { pokemonResults, pokemonUrl } = this.state;
+  
     return (
       <div className="App">
         <h1>Search for a Pokemon</h1>
         <SearchBox searchChange={this.onSearchChange} />
         <PokemonSearchResults
           onPokemonSelected={this.onPokemonSelected}
-          pokemonQuery={filteredPokemon}
+          pokemonQuery={pokemonResults}
         />
         <PokemonDisplay
           getPokemonData={this.pokeService.getPokemon}

--- a/pokemon-checker/src/DataTransferObjects/AbilityDTO.ts
+++ b/pokemon-checker/src/DataTransferObjects/AbilityDTO.ts
@@ -26,9 +26,8 @@ export class AbilityDTO {
     this.id = AbilityConstructorOptions.id ?? -1;
     this.effect = AbilityConstructorOptions.effect ?? "Missing Effect";
     this.pokemons = AbilityConstructorOptions.pokemons ?? [];
-    this.localizedName 
-      = AbilityConstructorOptions.localizedName ?? 
-      AbilityConstructorOptions.name;
+    this.localizedName =
+      AbilityConstructorOptions.localizedName ?? AbilityConstructorOptions.name;
   }
 
   public setDescription(effect: string) {

--- a/pokemon-checker/src/DataTransferObjects/AbilityDTO.ts
+++ b/pokemon-checker/src/DataTransferObjects/AbilityDTO.ts
@@ -9,6 +9,7 @@ export type AbilityConstructorOptions = {
   id?: number;
   effect?: string;
   pokemons?: ListOfPokemon[];
+  localizedName?: string;
 };
 
 export class AbilityDTO {
@@ -17,6 +18,7 @@ export class AbilityDTO {
   public id: number;
   public effect: string;
   public pokemons: ListOfPokemon[];
+  public localizedName: string;
 
   constructor(AbilityConstructorOptions: AbilityConstructorOptions) {
     this.name = AbilityConstructorOptions.name;
@@ -24,6 +26,9 @@ export class AbilityDTO {
     this.id = AbilityConstructorOptions.id ?? -1;
     this.effect = AbilityConstructorOptions.effect ?? "Missing Effect";
     this.pokemons = AbilityConstructorOptions.pokemons ?? [];
+    this.localizedName 
+      = AbilityConstructorOptions.localizedName ?? 
+      AbilityConstructorOptions.name;
   }
 
   public setDescription(effect: string) {
@@ -42,7 +47,8 @@ export class AbilityDTO {
       this.name.length > 0 &&
       this.url.length > 0 &&
       this.id > -1 &&
-      this.effect.length > 0
+      this.effect.length > 0 &&
+      this.localizedName.length > 0
     );
   }
 }

--- a/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/AbilityDisplay.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/AbilityDisplay.tsx
@@ -69,14 +69,14 @@ function RenderAbilityName(ability: pokemonAbilities): any {
   if (ability[1]) {
     return (
       <Grid container maxWidth="xs">
-        <Box sx={{ fontStyle: "italic" }}>{ability[0].name}</Box>
+        <Box sx={{ fontStyle: "italic" }}>{ability[0].localizedName}</Box>
       </Grid>
     );
   }
   return (
     <Grid container maxWidth="xs" sx={{ display: "flex" }}>
       <Box maxWidth="100%" sx={{ textAlign: "left" }}>
-        {ability[0].name}
+        {ability[0].localizedName}
       </Box>
     </Grid>
   );

--- a/pokemon-checker/src/components/PokemonDisplay/PokemonDisplay.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/PokemonDisplay.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import PokemonDTO from "../../DataTransferObjects/PokemonDTO";
-import { IPokemonData } from "../../interfaces/PokemonData";
 import { PokemonFactory } from "../../factories/PokemonFactory";
 import { QuickView } from "./PokemonQuickCardView";
 import "../../App.css";
@@ -15,8 +14,8 @@ const DisplayBorder = styled(Container)<ContainerProps>(({ theme }) => ({
 }));
 
 type displayProps = {
-  pokemonUrl: string;
   getPokemonData: (url: string) => Promise<any>;
+  pokemonUrl: string;
 };
 
 export const PokemonDisplay = (props: displayProps) => {
@@ -27,33 +26,23 @@ export const PokemonDisplay = (props: displayProps) => {
     () => new PokemonFactory(),
     []
   );
+  const { getPokemonData, pokemonUrl } = props;
   /**
    * Create a PokemonObject from the results retrieved
    * @param pokemonRetrieved the pokemon retrieved from the API
    */
-  const createPokemonObject = useCallback(
-    (pokemonRetrieved: IPokemonData): void => {
-      let pokemonToDisplay = pokemonFactory.createPokemon(pokemonRetrieved);
-      setPokemonObject(pokemonToDisplay);
-    },
-    [pokemonFactory]
-  );
-
-  // TODO: Eliminate this method. 'getPokemonData' as a Service method
-  // should already return the PokemonDTO - it currently returns raw JSON.
-  const fetchPokemonObject = useCallback(() => {
-    const url = props.pokemonUrl;
+  const createPokemonObject = useCallback((url: string) => {
     if (url && url.length > 0) {
-      props
-        .getPokemonData(url)
-        .then((pokemonRetrieved) => createPokemonObject(pokemonRetrieved))
-        .catch(console.log);
+      getPokemonData(url)
+      .then(data => pokemonFactory.createPokemon(data))
+      .then(pokemon => pokemonFactory.fetchAbilities(pokemon))
+      .then(pokemon => setPokemonObject(pokemon));
     }
-  }, [props, createPokemonObject]);
+  }, [getPokemonData, pokemonFactory]);
 
   useEffect(() => {
-    fetchPokemonObject();
-  }, [fetchPokemonObject]);
+    createPokemonObject(pokemonUrl);
+  }, [pokemonUrl, createPokemonObject],);
 
   if (pokemonObject) {
     return (

--- a/pokemon-checker/src/components/PokemonDisplay/PokemonDisplay.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/PokemonDisplay.tsx
@@ -31,18 +31,21 @@ export const PokemonDisplay = (props: displayProps) => {
    * Create a PokemonObject from the results retrieved
    * @param pokemonRetrieved the pokemon retrieved from the API
    */
-  const createPokemonObject = useCallback((url: string) => {
-    if (url && url.length > 0) {
-      getPokemonData(url)
-      .then(data => pokemonFactory.createPokemon(data))
-      .then(pokemon => pokemonFactory.fetchAbilities(pokemon))
-      .then(pokemon => setPokemonObject(pokemon));
-    }
-  }, [getPokemonData, pokemonFactory]);
+  const createPokemonObject = useCallback(
+    (url: string) => {
+      if (url && url.length > 0) {
+        getPokemonData(url)
+          .then((data) => pokemonFactory.createPokemon(data))
+          .then((pokemon) => pokemonFactory.fetchAbilities(pokemon))
+          .then((pokemon) => setPokemonObject(pokemon));
+      }
+    },
+    [getPokemonData, pokemonFactory]
+  );
 
   useEffect(() => {
     createPokemonObject(pokemonUrl);
-  }, [pokemonUrl, createPokemonObject],);
+  }, [pokemonUrl, createPokemonObject]);
 
   if (pokemonObject) {
     return (

--- a/pokemon-checker/src/components/PokemonSearch/PokemonId.tsx
+++ b/pokemon-checker/src/components/PokemonSearch/PokemonId.tsx
@@ -3,7 +3,7 @@ import Box from "@mui/system/box";
 type PokemonIdProps = {
   name: string;
   url: string;
-  onSelectPokemon: (name: string, url: string) => void;
+  onSelectPokemon: (url: string) => void;
   onPokemonClicked: React.Dispatch<React.SetStateAction<string>>;
   active: string;
 };
@@ -16,7 +16,7 @@ const PokemonId = ({
   active,
 }: PokemonIdProps) => {
   const pokemonClicked = (name: string, url: string) => {
-    onSelectPokemon(name, url);
+    onSelectPokemon(url);
     onPokemonClicked(name);
   };
 

--- a/pokemon-checker/src/components/PokemonSearch/PokemonSearchResults.tsx
+++ b/pokemon-checker/src/components/PokemonSearch/PokemonSearchResults.tsx
@@ -1,25 +1,21 @@
 import React, { useState } from "react";
 import PokemonId from "./PokemonId";
+import PokemonDTO from "../../DataTransferObjects/PokemonDTO"
 import Box from "@mui/system/box";
 
-export type PokemonSearchObj = {
-  name: string;
-  url: string;
-};
-
 export type PokemonSearchResultsProps = {
-  pokemonQuery: PokemonSearchObj[];
-  onPokemonSelected: (name: string, url: string) => void;
+  pokemonQuery: PokemonDTO[];
+  onPokemonSelected: (url: string) => void;
 };
 
 export default function PokemonSearchResults({
-  pokemonQuery,
   onPokemonSelected,
+  pokemonQuery,
 }: PokemonSearchResultsProps) {
   const [selectedPokemon, setSelectedPokemon] = useState("");
 
   let pokemonComponent: JSX.Element[] = [];
-  if (pokemonQuery) {
+  if (pokemonQuery && pokemonQuery.length > 0) {
     pokemonComponent = pokemonQuery.map((pokemon, p) => (
       <PokemonId
         key={p}

--- a/pokemon-checker/src/components/PokemonSearch/PokemonSearchResults.tsx
+++ b/pokemon-checker/src/components/PokemonSearch/PokemonSearchResults.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import PokemonId from "./PokemonId";
-import PokemonDTO from "../../DataTransferObjects/PokemonDTO"
+import PokemonDTO from "../../DataTransferObjects/PokemonDTO";
 import Box from "@mui/system/box";
 
 export type PokemonSearchResultsProps = {

--- a/pokemon-checker/src/components/SearchBar/SearchBar.tsx
+++ b/pokemon-checker/src/components/SearchBar/SearchBar.tsx
@@ -5,10 +5,10 @@ type SearchBoxProps = {
 };
 
 const SearchBox = ({ searchChange }: SearchBoxProps) => {
+
   return (
-    <div className="pa2">
+    <div>
       <input
-        className="pa3 ba b--green bg-lightest-blue"
         type="search"
         placeholder="Enter a Pokemon Name"
         onChange={searchChange}

--- a/pokemon-checker/src/components/SearchBar/SearchBar.tsx
+++ b/pokemon-checker/src/components/SearchBar/SearchBar.tsx
@@ -5,7 +5,6 @@ type SearchBoxProps = {
 };
 
 const SearchBox = ({ searchChange }: SearchBoxProps) => {
-
   return (
     <div>
       <input

--- a/pokemon-checker/src/factories/AbilityFactory.ts
+++ b/pokemon-checker/src/factories/AbilityFactory.ts
@@ -10,6 +10,7 @@ type AbilityDetails = {
   id: number;
   desc: string;
   pokemonHave: [];
+  localizedName: string;
 };
 
 export class AbilityFactory {
@@ -34,6 +35,7 @@ export class AbilityFactory {
     stub.effect = fullAbility.desc;
     stub.pokemons = fullAbility.pokemonHave;
     stub.id = fullAbility.id;
+    stub.localizedName = fullAbility.localizedName;
     return stub;
   };
 
@@ -52,6 +54,7 @@ export class AbilityFactory {
       id: data.id,
       desc: "Missing Effect Description",
       pokemonHave: [],
+      localizedName: "",
     };
 
     data.effect_entries.forEach((effect: any) => {
@@ -61,6 +64,24 @@ export class AbilityFactory {
         cleanedData.desc = effect.effect;
     });
     cleanedData.pokemonHave = data.pokemon;
+    //default option, just use the stub name
+    cleanedData.localizedName  
+      = this.findLocalizedName("en", data.names) ?? stub.name;
     return cleanedData;
   };
+
+  /**
+   * Find the localized name for the ability
+   * @param language the given language 
+   * todo: make a global map for how we define language vs the API
+   * @param data the fetched data
+   * @returns the localized name if found otherwise null 
+   * (which will default to the object name)
+   */
+  private findLocalizedName = (language: string, data: any): string | null => {
+    for (const value of data) {
+      if (value.language.name === "en") return value.name;
+    }
+    return null;
+  }
 }

--- a/pokemon-checker/src/factories/AbilityFactory.ts
+++ b/pokemon-checker/src/factories/AbilityFactory.ts
@@ -65,17 +65,17 @@ export class AbilityFactory {
     });
     cleanedData.pokemonHave = data.pokemon;
     //default option, just use the stub name
-    cleanedData.localizedName  
-      = this.findLocalizedName("en", data.names) ?? stub.name;
+    cleanedData.localizedName =
+      this.findLocalizedName("en", data.names) ?? stub.name;
     return cleanedData;
   };
 
   /**
    * Find the localized name for the ability
-   * @param language the given language 
+   * @param language the given language
    * todo: make a global map for how we define language vs the API
    * @param data the fetched data
-   * @returns the localized name if found otherwise null 
+   * @returns the localized name if found otherwise null
    * (which will default to the object name)
    */
   private findLocalizedName = (language: string, data: any): string | null => {
@@ -83,5 +83,5 @@ export class AbilityFactory {
       if (value.language.name === "en") return value.name;
     }
     return null;
-  }
+  };
 }

--- a/pokemon-checker/src/factories/PokemonFactory.ts
+++ b/pokemon-checker/src/factories/PokemonFactory.ts
@@ -58,7 +58,6 @@ export class PokemonFactory {
         //if retrieved from repository it likely has the data, otherwise...
         await this.abilityService.getFullAbilityDef(ability[0]);
     }));
-    console.log("complete");
     return pokemon;
   }
 

--- a/pokemon-checker/src/factories/PokemonFactory.ts
+++ b/pokemon-checker/src/factories/PokemonFactory.ts
@@ -49,13 +49,18 @@ export class PokemonFactory {
     const createdPokemon = new PokemonDTO(
       this.getFullPokemonConstructorProps(pokemon)
     );
-    createdPokemon.abilities.forEach((ability) => {
-      if (!ability[0].hasFullData)
-        //if retrieved from repository it likely has the data, otherwise...
-        this.abilityService.getFullAbilityDef(ability[0]);
-    });
     return createdPokemon;
   };
+
+  public fetchAbilities = async (pokemon : PokemonDTO): Promise<PokemonDTO> => {
+    await Promise.all(pokemon.abilities.map(async (ability) => {
+      if (!ability[0].hasFullData)
+        //if retrieved from repository it likely has the data, otherwise...
+        await this.abilityService.getFullAbilityDef(ability[0]);
+    }));
+    console.log("complete");
+    return pokemon;
+  }
 
   /**
    * Creates a partial pokemon DTO


### PR DESCRIPTION
1. removed Tachyons (was used as some quick way to write CSS when I was still learning) from the project and updated SearchBar.tsx
2. Fix an error where there was a white bar at top of the app (overflow in APP.css)
3. Added new value to Ability "localizedName" which we can build off of for multi language support
4. Cleaned up App.tsx to remove unneeded states, and functions, will help with future optimizations on renders since most of the clutter is gone
5. fetchAbilities moved outside into its own function to allow async solution
6. Made it so abilities now render the localized name instead of the generic name from the API

The reason this commit was long was because I was struggling to have the localizedName load because of the new hooks in PokemonDisplay, this caused me searching for a solution in App.tsx which got me cleaning it up. The solution now is before the pokemon renders we fetch the mon's abilities. I don't like this solution because now pokemon load slowly while it waits for up to 3 fetches.

Alternative solution would be a blank placeholder until the promise resolves and then re-render the ability display. I wasn't able to get far with it because of how the flow exists. First we fetch pokemon (async) -> create pokemon -> create abilities (async)-> display, while it did work, I couldn't get the hooks to re render the object when the promise resolved for abilities (get useEffect to detect that pokemonObject.abilities changed for example) , except for one time but then it continued to render loop forever. This is something we should look at as it will also effect future components like moves.