### PR TITLE
Decoupled PokemonFactory from PokemonDisplay.tsx

### DIFF
--- a/pokemon-checker/src/components/PokemonDisplay/PokemonDisplay.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/PokemonDisplay.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import PokemonDTO from "../../DataTransferObjects/PokemonDTO";
-import { PokemonFactory } from "../../factories/PokemonFactory";
 import { QuickView } from "./PokemonQuickCardView";
 import "../../App.css";
 import WaitingView from "./DefaultDisplayView";
@@ -20,12 +19,6 @@ type displayProps = {
 
 export const PokemonDisplay = (props: displayProps) => {
   const [pokemonObject, setPokemonObject] = useState<PokemonDTO>();
-  // TODO (jeremy): Elminate the factory declaration! The service method is
-  // passed to this component as a prop.
-  const pokemonFactory: PokemonFactory = useMemo(
-    () => new PokemonFactory(),
-    []
-  );
   const { getPokemonData, pokemonUrl } = props;
   /**
    * Create a PokemonObject from the results retrieved
@@ -35,12 +28,10 @@ export const PokemonDisplay = (props: displayProps) => {
     (url: string) => {
       if (url && url.length > 0) {
         getPokemonData(url)
-          .then((data) => pokemonFactory.createPokemon(data))
-          .then((pokemon) => pokemonFactory.fetchAbilities(pokemon))
           .then((pokemon) => setPokemonObject(pokemon));
       }
     },
-    [getPokemonData, pokemonFactory]
+    [getPokemonData]
   );
 
   useEffect(() => {

--- a/pokemon-checker/src/services/PokemonService.ts
+++ b/pokemon-checker/src/services/PokemonService.ts
@@ -1,5 +1,6 @@
 import { PokemonRepository } from "../repositories/PokemonRepository";
 import { PokemonFactory } from "../factories/PokemonFactory";
+import { IPokemonData } from "../interfaces/PokemonData";
 import PokemonDTO from "../DataTransferObjects/PokemonDTO";
 
 /**
@@ -65,8 +66,6 @@ export class PokemonService {
     // Store the pokemon names in the repository
     this.storePokemonStubs(filterResults);
 
-    // console.log(filterResults);
-
     return filterResults;
   };
 
@@ -87,7 +86,14 @@ export class PokemonService {
    * Lookup an individual pokemon
    * @param url the url for the specific pokemon
    */
-  public getPokemon(url: string): Promise<any> {
-    return fetch(url).then((response) => response.json());
-  }
+  public getPokemon = async (url: string) => {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(response.statusText);
+    } else {
+      const data = await response.json();
+      const pokemonPayload = data as IPokemonData;
+      return this.factory.createPokemon(pokemonPayload);
+    }
+  };
 }


### PR DESCRIPTION
Removed a small thorn from `PokemonDisplay.tsx`. As a view class, it really has no business trying to create DTOs. For this first pass fix, the service now performs the fetch and uses the factory to return a proper DTO, as it should have done in the first place.

The `getPokemon` method in the service was a simple fetch + dump of raw JSON. Because of ESLint, that's now been converted to an `async` function.

In order to maintain class context I've changed the declaration to an arrow function (some more details on that [here](https://stackoverflow.com/questions/56570084/properties-are-undefined-inside-of-promises) and [here](https://stackoverflow.com/questions/34930771/why-is-this-undefined-inside-class-method-when-using-promises).)

If the get method was declared in this style:

`public getPokemon(url: string) { ... }`

Then the inside of the method would say `this` is `undefined`. It's been converted to an arrow:

`public getPokemon = async (url: string) => { ... }`

And now it remembers its class properties.