### PR TITLE
Added test and fixed missing ability info

### DIFF
--- a/pokemon-checker/src/factories/PokemonFactory.ts
+++ b/pokemon-checker/src/factories/PokemonFactory.ts
@@ -45,21 +45,28 @@ export class PokemonFactory {
    * Creates pokemon data that can be used for rendering
    * @param pokemon Full data from the individual pokemon requests
    */
-  public createPokemon = (pokemon: IPokemonData): PokemonDTO => {
+  public createPokemon = async (pokemon: IPokemonData): Promise<PokemonDTO> => {
     const createdPokemon = new PokemonDTO(
       this.getFullPokemonConstructorProps(pokemon)
     );
-    return createdPokemon;
+    //fetch abilities
+    //ToDo: expand this to be more general, will help when we have to fetch
+    //moves and other calls that can take time by making them async but wait
+    //until all the details are returned
+    const pokeWithAbilities = this.fetchAbilities(createdPokemon);
+    return pokeWithAbilities;
   };
 
-  public fetchAbilities = async (pokemon : PokemonDTO): Promise<PokemonDTO> => {
-    await Promise.all(pokemon.abilities.map(async (ability) => {
-      if (!ability[0].hasFullData)
-        //if retrieved from repository it likely has the data, otherwise...
-        await this.abilityService.getFullAbilityDef(ability[0]);
-    }));
+  private fetchAbilities = async (pokemon: PokemonDTO): Promise<PokemonDTO> => {
+    await Promise.all(
+      pokemon.abilities.map(async (ability) => {
+        if (!ability[0].hasFullData)
+          //if retrieved from repository it likely has the data, otherwise...
+          await this.abilityService.getFullAbilityDef(ability[0]);
+      })
+    );
     return pokemon;
-  }
+  };
 
   /**
    * Creates a partial pokemon DTO

--- a/pokemon-checker/src/services/AbilityService.test.ts
+++ b/pokemon-checker/src/services/AbilityService.test.ts
@@ -34,4 +34,8 @@ test("Test pokemonList fetched properly", () => {
   expect(fetchedAbility.pokemons).toEqual(pressureAbility.pokemons);
 });
 
+test("Test localized ability name fetched properly", () => {
+  expect(fetchedAbility.localizedName).toBe(pressureAbility.localizedName);
+});
+
 //mock browser data and test if AbilityService is actually storying/retrieving from localstorage

--- a/pokemon-checker/src/services/AbilityService.ts
+++ b/pokemon-checker/src/services/AbilityService.ts
@@ -52,15 +52,18 @@ export class AbilityService {
     return abilityStub;
   }
 
-  public getFullAbilityDef(ability: AbilityDTO): Promise<AbilityDTO> {
+  public async getFullAbilityDef(ability: AbilityDTO): Promise<AbilityDTO> {
     const repResult = this.repositoryLookup(ability.name);
-    if (repResult && repResult.hasFullData) return Promise.resolve(repResult);
+    if (repResult && repResult.hasFullData) 
+      return await Promise.resolve(repResult);
 
-    return fetch(ability.url)
-      .then((response) => response.json())
-      .then((jsonResponse: Promise<any>) =>
-        this.resolveAbilityStub(jsonResponse, ability)
-      );
+    const response = await fetch(ability.url)
+    if (!response.ok) {
+      throw new Error(response.statusText);
+    } else {
+      const data = await response.json();
+      return this.resolveAbilityStub(data, ability);
+    }
   }
 
   private resolveAbilityStub = async (

--- a/pokemon-checker/src/services/PokemonService.ts
+++ b/pokemon-checker/src/services/PokemonService.ts
@@ -93,8 +93,7 @@ export class PokemonService {
     } else {
       const data = await response.json();
       const pokemonPayload = data as IPokemonData;
-      const pokemon = this.factory.createPokemon(pokemonPayload);
-      return pokemon;
+      return this.factory.createPokemon(pokemonPayload);
     }
   };
 }

--- a/pokemon-checker/src/services/PokemonService.ts
+++ b/pokemon-checker/src/services/PokemonService.ts
@@ -93,7 +93,9 @@ export class PokemonService {
     } else {
       const data = await response.json();
       const pokemonPayload = data as IPokemonData;
-      return this.factory.createPokemon(pokemonPayload);
+      const pokemon = this.factory.createPokemon(pokemonPayload);
+      await this.factory.fetchAbilities(pokemon);
+      return pokemon;
     }
   };
 }

--- a/pokemon-checker/src/services/PokemonService.ts
+++ b/pokemon-checker/src/services/PokemonService.ts
@@ -94,7 +94,6 @@ export class PokemonService {
       const data = await response.json();
       const pokemonPayload = data as IPokemonData;
       const pokemon = this.factory.createPokemon(pokemonPayload);
-      await this.factory.fetchAbilities(pokemon);
       return pokemon;
     }
   };


### PR DESCRIPTION
Added localizedName test
Converted a .then chain function into an async/await function
Added a call to the fetchAbilities function in the getPokemon
Resolves: #87 
I think its reasonable to expect the `PokemonService `to start the process of fetching the associated entities in the `PokemonFactory`. When it comes to other entities (abilities, moves, and later down the road possibly language, generation etc) what is the proper flow? Should it be the responsibility of `PokemonDisplay`? For me it makes sense that once a Pokemon is fetched and created, we asynchronously fetch its associated data so it would belong in `PokemonService`. At this point is where I fail to understand what is proper DDD