### PR TITLE
Added css to body to prevent MUI model from adding a padding

### DIFF
--- a/pokemon-checker/src/App.css
+++ b/pokemon-checker/src/App.css
@@ -15,3 +15,7 @@ body,
   font-size: calc(10px + 2vmin);
   color: white;
 }
+
+body {
+  padding-right: 0 !important
+}


### PR DESCRIPTION
There's a weird issue with MUI when using something that inherits a model (like popover) in which it tries to hide scrollbar to prevent scrolling while an item has a popover displayed. What's happening is its just adding a ~17px border to the right in the body.