### PR TITLE
Updated shiny display to be an icon button

### DIFF
--- a/pokemon-checker/package-lock.json
+++ b/pokemon-checker/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "pokemon-checker",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pokemon-checker",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
+        "@mui/icons-material": "^5.8.0",
         "@mui/material": "^5.5.3",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^9.5.0",
@@ -3066,6 +3067,31 @@
         "@types/react": "^16.8.6 || ^17.0.0",
         "react": "^17.0.0",
         "react-dom": "^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.8.0.tgz",
+      "integrity": "sha512-ScwLxa0q5VYV70Jfc60V/9VD0b9SvIeZ0Jddx2Dt2pBUFFO9vKdrbt9LYiT+4p21Au5NdYIb2XSHj46CLN1v3g==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -18475,6 +18501,14 @@
         "clsx": "^1.1.1",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2"
+      }
+    },
+    "@mui/icons-material": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.8.0.tgz",
+      "integrity": "sha512-ScwLxa0q5VYV70Jfc60V/9VD0b9SvIeZ0Jddx2Dt2pBUFFO9vKdrbt9LYiT+4p21Au5NdYIb2XSHj46CLN1v3g==",
+      "requires": {
+        "@babel/runtime": "^7.17.2"
       }
     },
     "@mui/material": {

--- a/pokemon-checker/package.json
+++ b/pokemon-checker/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
+    "@mui/icons-material": "^5.8.0",
     "@mui/material": "^5.5.3",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^9.5.0",

--- a/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/PokemonImageDisplay.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/PokemonImageDisplay.tsx
@@ -6,8 +6,7 @@
 
 type PokemonImageProps = {
   altImageName: string;
-  defaultFront: string;
-  defaultFrontS: string;
+  spriteImage: string;
 };
 
 const imageStyles = {
@@ -17,8 +16,7 @@ const imageStyles = {
 
 export const PokemonImage = ({
   altImageName,
-  defaultFront,
-  defaultFrontS,
+  spriteImage,
 }: PokemonImageProps) => {
   return (
     <div>
@@ -26,21 +24,10 @@ export const PokemonImage = ({
         <img
           className="pokemonDisplay"
           style={imageStyles}
-          src={defaultFront}
+          src={spriteImage}
           alt={altImageName}
         ></img>
       }
-      {defaultFrontS ? (
-        <img
-          className="pokemonDisplay"
-          style={imageStyles}
-          src={defaultFrontS}
-          alt={altImageName}
-        ></img>
-      ) : (
-        //Pokemon should have a shiny, if not then we should log the error
-        <h2>No Shiny</h2>
-      )}
     </div>
   );
 };

--- a/pokemon-checker/src/components/PokemonDisplay/PokemonQuickCardView.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/PokemonQuickCardView.tsx
@@ -7,14 +7,14 @@ import PokemonImage from "./DisplayFunctionalComponents/PokemonImageDisplay";
 import PokemonDTO from "../../DataTransferObjects/PokemonDTO";
 import Grid, { GridProps } from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
-import FlareIcon from '@mui/icons-material/Flare';
+import FlareIcon from "@mui/icons-material/Flare";
 import { styled } from "@mui/material/styles";
-import { shinyTheme } from "../../userinterface/CustomThemes"
+import { shinyTheme } from "../../userinterface/CustomThemes";
 import { useEffect } from "react";
 
 const ShinyButtonDisplay = styled(Grid)<GridProps>(({ theme }) => ({
-  alignSelf: 'flex-start',
-  position: 'absolute',
+  alignSelf: "flex-start",
+  position: "absolute",
 }));
 
 const SpriteDisplay = styled(Grid)<GridProps>(({ theme }) => ({
@@ -31,19 +31,19 @@ type PokemonInfoProps = {
 
 export const QuickView = ({ pokemon }: PokemonInfoProps) => {
   const [displayDefault, setSpriteDisplay] = useState(true);
-  const {primary, secondary} = shinyTheme.palette;
+  const { primary, secondary } = shinyTheme.palette;
   useEffect(() => {
     setSpriteDisplay(true);
-  }, [pokemon])
+  }, [pokemon]);
 
   return (
     <Grid container alignItems="center" columnSpacing={2}>
-      <ShinyButtonDisplay 
+      <ShinyButtonDisplay
         theme={shinyTheme}
-        display={pokemon.frontShiny ? true : false}
-        color={displayDefault ? primary.main : secondary.main}>
+        color={displayDefault ? primary.main : secondary.main}
+      >
         <label htmlFor="icon-button-file">
-          <IconButton 
+          <IconButton
             color="inherit"
             onClick={() => setSpriteDisplay(!displayDefault)}
           >
@@ -55,9 +55,7 @@ export const QuickView = ({ pokemon }: PokemonInfoProps) => {
         <PokemonImage
           altImageName={pokemon.name}
           spriteImage={
-            displayDefault ? 
-            pokemon.frontDefault : 
-            pokemon.frontShiny
+            displayDefault ? pokemon.frontDefault : pokemon.frontShiny
           }
         />
       </SpriteDisplay>

--- a/pokemon-checker/src/components/PokemonDisplay/PokemonQuickCardView.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/PokemonQuickCardView.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import NameDisplay from "./DisplayFunctionalComponents/NameDisplay";
 import StatDisplay from "./DisplayFunctionalComponents/StatDisplay";
 import TypeDisplay from "./DisplayFunctionalComponents/TypeDisplay";
@@ -5,7 +6,16 @@ import AbilityDisplay from "./DisplayFunctionalComponents/AbilityDisplay";
 import PokemonImage from "./DisplayFunctionalComponents/PokemonImageDisplay";
 import PokemonDTO from "../../DataTransferObjects/PokemonDTO";
 import Grid, { GridProps } from "@mui/material/Grid";
+import IconButton from "@mui/material/IconButton";
+import FlareIcon from '@mui/icons-material/Flare';
 import { styled } from "@mui/material/styles";
+import { shinyTheme } from "../../userinterface/CustomThemes"
+import { useEffect } from "react";
+
+const ShinyButtonDisplay = styled(Grid)<GridProps>(({ theme }) => ({
+  alignSelf: 'flex-start',
+  position: 'absolute',
+}));
 
 const SpriteDisplay = styled(Grid)<GridProps>(({ theme }) => ({
   alignSelf: `center`,
@@ -20,13 +30,35 @@ type PokemonInfoProps = {
 };
 
 export const QuickView = ({ pokemon }: PokemonInfoProps) => {
+  const [displayDefault, setSpriteDisplay] = useState(true);
+  const {primary, secondary} = shinyTheme.palette;
+  useEffect(() => {
+    setSpriteDisplay(true);
+  }, [pokemon])
+
   return (
     <Grid container alignItems="center" columnSpacing={2}>
-      <SpriteDisplay item xs={12} sm={6}>
+      <ShinyButtonDisplay 
+        theme={shinyTheme}
+        display={pokemon.frontShiny ? true : false}
+        color={displayDefault ? primary.main : secondary.main}>
+        <label htmlFor="icon-button-file">
+          <IconButton 
+            color="inherit"
+            onClick={() => setSpriteDisplay(!displayDefault)}
+          >
+            <FlareIcon />
+          </IconButton>
+        </label>
+      </ShinyButtonDisplay>
+      <SpriteDisplay item xs={9} sm={6}>
         <PokemonImage
           altImageName={pokemon.name}
-          defaultFront={pokemon.frontDefault}
-          defaultFrontS={pokemon.frontShiny}
+          spriteImage={
+            displayDefault ? 
+            pokemon.frontDefault : 
+            pokemon.frontShiny
+          }
         />
       </SpriteDisplay>
       <BasicInfoDisplay item xs={12} sm={6}>

--- a/pokemon-checker/src/userinterface/CustomThemes.ts
+++ b/pokemon-checker/src/userinterface/CustomThemes.ts
@@ -1,0 +1,12 @@
+import { createTheme } from "@mui/material/styles";
+
+export const shinyTheme = createTheme({
+  palette: {
+    primary: {
+      main: '#ffffff',
+    },
+    secondary: {
+      main: '#ffff00',
+    },
+  }
+})


### PR DESCRIPTION
Note: requires an npm install due to adding mui-icons

-added a toggle to swap between defult/shiny sprite
-created a userinterface directory in root with the idea of holding UI settings like themes and potentially styles to lower clutter in view files and promote reusable styles