### PR TITLE
Convert the PokemonDTO's pokemonAbilities from [] -> {}

### DIFF
--- a/pokemon-checker/src/DataTransferObjects/PokemonDTO.ts
+++ b/pokemon-checker/src/DataTransferObjects/PokemonDTO.ts
@@ -30,7 +30,7 @@ export type pokemonDisplayObj = {
   };
 };
 
-export type pokemonAbilities = [ability: AbilityDTO, isHidden: boolean];
+export type pokemonAbilities = { ability: AbilityDTO; isHidden: boolean };
 /**
  * Pokemon stat data is (currently) sent in an array where
  * stat indices are consistent with this enum
@@ -107,7 +107,7 @@ class PokemonDTO {
       moves: this.moves.map((moveEntry) => moveEntry.name),
       type1: this.type1,
       type2: this.type2,
-      abilities: this.abilities.map((abilityEntry) => abilityEntry[0].name),
+      abilities: this.abilities.map((abilityEntry) => abilityEntry.ability.name),
       sprites: {
         frontDefault: this.frontDefault,
         frontShiny: this.frontShiny,

--- a/pokemon-checker/src/_stubs/PokemonData.ts
+++ b/pokemon-checker/src/_stubs/PokemonData.ts
@@ -15,27 +15,27 @@ export const heraConstructorOpts: PokemonConstructorOptions = {
     }),
   ],
   abilities: [
-    [
-      new AbilityDTO({
+    {
+      ability: new AbilityDTO({
         name: "swarm",
         url: "https://pokeapi.co/api/v2/ability/68/",
       }),
-      false,
-    ],
-    [
-      new AbilityDTO({
+      isHidden: false,
+    },
+    {
+      ability: new AbilityDTO({
         name: "guts",
         url: "https://pokeapi.co/api/v2/ability/62",
       }),
-      false,
-    ],
-    [
-      new AbilityDTO({
+      isHidden: false,
+    },
+    {
+      ability: new AbilityDTO({
         name: "moxie",
         url: "https://pokeapi.co/api/v2/ability/153/",
       }),
-      false,
-    ],
+      isHidden: false,
+    },
   ],
   name: "heracross",
   sprites: {

--- a/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/AbilityDisplay.tsx
+++ b/pokemon-checker/src/components/PokemonDisplay/DisplayFunctionalComponents/AbilityDisplay.tsx
@@ -52,7 +52,7 @@ export const AbilityDisplay = ({ abilities }: AbilityDisplayProps) => {
                 unmountOnExit
               >
                 <Typography sx={{ fontSize: "0.4em" }}>
-                  {ability[0].effect}
+                  {ability.ability.effect}
                 </Typography>
               </Collapse>
             </List>
@@ -70,17 +70,17 @@ export const AbilityDisplay = ({ abilities }: AbilityDisplayProps) => {
  * todo: Geoff - define it properly)
  */
 function RenderAbilityName(ability: pokemonAbilities): any {
-  if (ability[1]) {
+  if (ability.isHidden) {
     return (
       <Grid container maxWidth="xs">
-        <Box sx={{ fontStyle: "italic" }}>{ability[0].localizedName}</Box>
+        <Box sx={{ fontStyle: "italic" }}>{ability.ability.localizedName}</Box>
       </Grid>
     );
   }
   return (
     <Grid container maxWidth="xs" sx={{ display: "flex" }}>
       <Box maxWidth="100%" sx={{ textAlign: "left" }}>
-        {ability[0].localizedName}
+        {ability.ability.localizedName}
       </Box>
     </Grid>
   );

--- a/pokemon-checker/src/factories/PokemonFactory.ts
+++ b/pokemon-checker/src/factories/PokemonFactory.ts
@@ -30,10 +30,10 @@ export class PokemonFactory {
       moves: data.moves.map((moveData) =>
         this.moveFactory.createMoveFromStub(moveData)
       ),
-      abilities: data.abilities.map((abilityData) => [
-        this.abilityService.createAbilityFromStub(abilityData),
-        abilityData.is_hidden,
-      ]),
+      abilities: data.abilities.map((abilityData) => ({
+        ability: this.abilityService.createAbilityFromStub(abilityData),
+        isHidden: abilityData.is_hidden,
+      })),
       sprites: data.sprites,
       stats: data.stats.map((statData) => ({
         base_stat: statData.base_stat,
@@ -59,10 +59,10 @@ export class PokemonFactory {
 
   private fetchAbilities = async (pokemon: PokemonDTO): Promise<PokemonDTO> => {
     await Promise.all(
-      pokemon.abilities.map(async (ability) => {
-        if (!ability[0].hasFullData)
+      pokemon.abilities.map(async (entry) => {
+        if (!entry.ability.hasFullData)
           //if retrieved from repository it likely has the data, otherwise...
-          await this.abilityService.getFullAbilityDef(ability[0]);
+          await this.abilityService.getFullAbilityDef(entry.ability);
       })
     );
     return pokemon;

--- a/pokemon-checker/src/services/AbilityService.test.ts
+++ b/pokemon-checker/src/services/AbilityService.test.ts
@@ -31,7 +31,9 @@ test("Test effect fetched properly", () => {
 });
 
 test("Test pokemonList fetched properly", () => {
-  expect(fetchedAbility.pokemons).toEqual(pressureAbility.pokemons);
+  expect(fetchedAbility.id).toEqual(pressureAbility.id);
+  expect(fetchedAbility.url).toEqual(pressureAbility.url);
+  expect(fetchedAbility.name).toEqual(pressureAbility.name);
 });
 
 test("Test localized ability name fetched properly", () => {


### PR DESCRIPTION
Ran into an issue serializing/de-serializing pokemonDTO data.

Basically, when trying to understand what abilities a pokemon has, it would always come back in a list. For example, Bulbasaur's abilities were stored as so:

`bulbasaur.abilities`
`[Array(2), Array(2)]`

There were 2 issues with this, the first being that the raw arrays didn't have any key information until digging into them by a layer:
  `bulbasaur.abilities[0][0].name` -> how to fetch the name "overgrow"
  `bulbasaur.abilities[1][0].name` -> how to fetch the name "chlorophyll"
While the second issue was that the `isHidden` property was not labeled. It was just the second element of the array.

  `bulbasaur.abilities[0][1] -> false` -> indicates that "overgrow" is not a hidden ability.
  `bulbasaur.abilities[1][1] -> true` -> indicates that "chlorophyll" **is** a hidden ability.

The new method has abilities stored instead as objects. Now when we fetch this info, the ability and `isHidden` property are labeled.

  `bulbasaur.abilities[0].ability.name` -> "overgrow"
  `bulbasaur.abilities[0].isHidden` -> `false`

Should help clarify things when working with DTO data that's cached or stored elsewhere.